### PR TITLE
Add example: get PDF contents as a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ pdf = CombinePDF.parse(pdf_data)
 
 Loading from the memory is especially effective for importing PDF data recieved through the internet or from a different authoring library such as Prawn.
 
+Similarly, you can output a string of PDF data using `.to_pdf`. For example, to let a user download the PDF from a Rails app:
+
+```
+# in a controller action
+send_data combined_file.to_pdf, filename: "combined.pdf", type: "application/pdf"
+```
+
 Demo
 ====
 


### PR DESCRIPTION
The Rails example may be too far off-topic, but I wanted to show some application where you wouldn't want to save to disk, and generally "a server response" is what I had in mind.