### PR TITLE
Fix typo in parser advancing warning

### DIFF
--- a/lib/combine_pdf/parser.rb
+++ b/lib/combine_pdf/parser.rb
@@ -399,8 +399,8 @@ module CombinePDF
 					fresh = false
 				else
 					# always advance
-					# warn "Advnacing for unknown reason... #{@scanner.peek(4)}" unless @scanner.peek(1) =~ /[\s\n]/
-					warn "Warning: parser advnacing for unknown reason. Potential data-loss."
+					# warn "Advancing for unknown reason... #{@scanner.peek(4)}" unless @scanner.peek(1) =~ /[\s\n]/
+					warn "Warning: parser advancing for unknown reason. Potential data-loss."
 					@scanner.pos = @scanner.pos + 1
 				end
 			end


### PR DESCRIPTION
`advnacing => advancing`