### PR TITLE
fix typo in the parser

### DIFF
--- a/lib/combine_pdf/parser.rb
+++ b/lib/combine_pdf/parser.rb
@@ -288,8 +288,8 @@ module CombinePDF
                 str << 9 # tab
               when 98 # b
                 str << 8
-              when 102 # f
-                str << 255
+              when 102 # f, form-feed
+                str << 12
               when 48..57 # octal notation for byte?
                 rep = rep.chr
                 rep += str_bytes.shift.chr if str_bytes[0].between?(48, 57)


### PR DESCRIPTION
 - `\f` represents the form-feed character (`0x0C`)
 - `form-feed` is usually abbreviated as FF, and I think that's why it was mistaken as 255 (`0xFF`)
 - among other things, this had a major impact on encrypted PDFs for me because keys were incorrectly decoded