### PR TITLE
Restore previous logic in PageMethods::inject_page.

### DIFF
--- a/lib/combine_pdf/page_methods.rb
+++ b/lib/combine_pdf/page_methods.rb
@@ -63,14 +63,14 @@ module CombinePDF
       # injecting each of the values in the injected Page
       res = resources
       obj.resources.each do |key, new_val|
-        if !PDF::PRIVATE_HASH_KEYS.include?(key) # keep CombinePDF structual data intact.
-          next unless res[key].nil?
-          res[key] = new_val
-        elsif res[key].is_a?(Hash) && new_val.is_a?(Hash)
-          new_val = new_val[:referenced_object] || new_val
-          new_val.update (res[key][:referenced_object] || res[key]) # make sure the old values are respected
-          (res[key][:referenced_object] || res[key]).update new_val # transfer old and new values to the injected page
-          # Do nothing if array - ot is the PROC array, which is an issue
+        unless PDF::PRIVATE_HASH_KEYS.include? key # keep CombinePDF structual data intact.
+          if res[key].nil?
+            res[key] = new_val
+          elsif res[key].is_a?(Hash) && new_val.is_a?(Hash)
+            new_val = new_val[:referenced_object] || new_val
+            new_val.update (res[key][:referenced_object] || res[key]) # make sure the old values are respected
+            (res[key][:referenced_object] || res[key]).update new_val # transfer old and new values to the injected page
+          end #Do nothing if array - ot is the PROC array, which is an issue
         end
       end
       resources[:ProcSet] = [:PDF, :Text, :ImageB, :ImageC, :ImageI] # this was recommended by the ISO. 32000-1:2008

--- a/lib/combine_pdf/page_methods.rb
+++ b/lib/combine_pdf/page_methods.rb
@@ -63,15 +63,16 @@ module CombinePDF
       # injecting each of the values in the injected Page
       res = resources
       obj.resources.each do |key, new_val|
-        unless PDF::PRIVATE_HASH_KEYS.include? key # keep CombinePDF structual data intact.
-          if res[key].nil?
-            res[key] = new_val
-          elsif res[key].is_a?(Hash) && new_val.is_a?(Hash)
-            new_val = new_val[:referenced_object] || new_val
-            new_val.update (res[key][:referenced_object] || res[key]) # make sure the old values are respected
-            (res[key][:referenced_object] || res[key]).update new_val # transfer old and new values to the injected page
-          end #Do nothing if array - ot is the PROC array, which is an issue
-        end
+        # keep CombinePDF structural data intact.
+        next if PDF::PRIVATE_HASH_KEYS.include?(key)
+
+        if res[key].nil?
+          res[key] = new_val
+        elsif res[key].is_a?(Hash) && new_val.is_a?(Hash)
+          new_val = new_val[:referenced_object] || new_val
+          new_val.update (res[key][:referenced_object] || res[key]) # make sure the old values are respected
+          (res[key][:referenced_object] || res[key]).update new_val # transfer old and new values to the injected page
+        end #Do nothing if array - ot is the PROC array, which is an issue
       end
       resources[:ProcSet] = [:PDF, :Text, :ImageB, :ImageC, :ImageI] # this was recommended by the ISO. 32000-1:2008
 


### PR DESCRIPTION
The change I reverted was breaking my app's test suite. I'm not exactly sure
why, but I think there was an unintended logic change when the code was
beautified.

I haven't been able to run the test suite. It looks like I'm missing some PDF
fixture files. So, please run the test suite on my branch before merging it!

Thanks again for the handy gem!