### PR TITLE
fix incorrect mapping of 0xFF to \\f

### DIFF
--- a/lib/combine_pdf/renderer.rb
+++ b/lib/combine_pdf/renderer.rb
@@ -33,12 +33,12 @@ module CombinePDF
                                 "\x0D" => '\\r',
                                 "\x09" => '\\t',
                                 "\x08" => '\\b',
-                                "\xFF" => '\\f',
+                                "\x0C" => '\\f',  # form-feed (\f) == 0x0C
                                 "\x28" => '\\(',
                                 "\x29" => '\\)',
                                 "\x5C" => '\\\\' }.dup
     32.times { |i| STRING_REPLACEMENT_HASH[i.chr] ||= "\\#{i}" }
-    (256 - 128).times { |i| STRING_REPLACEMENT_HASH[(i + 127).chr] ||= "\\#{i + 127}" }
+    (256 - 127).times { |i| STRING_REPLACEMENT_HASH[(i + 127).chr] ||= "\\#{i + 127}" }
 
     def format_string_to_pdf(object)
       # object.force_encoding(Encoding::ASCII_8BIT)


### PR DESCRIPTION
 - related to #72. 
 - `0xFF` should be mapped to `"\\255"`
 - mapping `0x0C` to '\\f' was being added by `32.times` block
 - fix: add (redundant) `0x0C` to `\f` mapping and fix boundary of 2nd times block