### PR TITLE
fix Acrobat issue with duplicated pages

### DIFF
--- a/lib/combine_pdf/pdf_protected.rb
+++ b/lib/combine_pdf/pdf_protected.rb
@@ -30,7 +30,7 @@ module CombinePDF
           next if resolved.include? obj.object_id
           resolved << obj.object_id
           if obj[:referenced_object]
-            tmp = @objects.find_index(obj[:referenced_object])
+            tmp = @objects.find_index { |o| o.object_id == obj[:referenced_object].object_id }
             if tmp
               tmp = @objects[tmp]
               obj[:referenced_object] = tmp

--- a/lib/combine_pdf/pdf_protected.rb
+++ b/lib/combine_pdf/pdf_protected.rb
@@ -30,7 +30,15 @@ module CombinePDF
           next if resolved.include? obj.object_id
           resolved << obj.object_id
           if obj[:referenced_object]
-            tmp = @objects.find_index { |o| o.object_id == obj[:referenced_object].object_id }
+            # fix Acrobat Reader issue with Page reference uniqueness
+            # Page reference must be unique or some versions of Acrobat Reader will fail w/ error(14)
+            if obj[:referenced_object][:Type] == :Page
+              tmp = @objects.find_index { |o| o.object_id == obj[:referenced_object].object_id }
+            else
+              # for other types, find an identical object
+              tmp = @objects.find_index(obj[:referenced_object])
+            end
+
             if tmp
               tmp = @objects[tmp]
               obj[:referenced_object] = tmp


### PR DESCRIPTION
 - special case in [`rebuild_catalog_and_objects`] (https://github.com/boazsegev/combine_pdf/blob/master/lib/combine_pdf/pdf_protected.rb#L172-L177) doesn't work because of [incorrect use of `find_index`](https://github.com/boazsegev/combine_pdf/blob/master/lib/combine_pdf/pdf_protected.rb#L33) in `add_referenced`
 - `Array#find_index` uses `==` to find a match. see http://ruby-doc.org/core-2.2.0/Array.html#method-i-find_index
 - but `Hash` equality doesn't compare the object ids. see http://ruby-doc.org/core-2.2.0/Hash.html#method-i-3D-3D
 - example 
```ruby
hash1 = { a: 1 }
hash2 = { a: 1 }

p hash1 == hash2    # -> true
p hash1.object_id == hash2.object_id    # -> false
p [hash1, hash2].find_index(hash2)    # -> 0
p [hash1, hash2].find_index { |el| el.object_id == hash2.object_id }    # -> 1
```