### PR TITLE
Use object_id as hash key instead of whole object.

### DIFF
--- a/lib/combine_pdf/pdf_protected.rb
+++ b/lib/combine_pdf/pdf_protected.rb
@@ -25,7 +25,7 @@ module CombinePDF
       # an existing object map
       resolved = {}.dup
       existing = {}.dup
-      @objects.each { |obj| existing[obj] = obj }
+      @objects.each { |obj| existing[obj.object_id] = obj }
       # loop until should_resolve is empty
       while should_resolve.any?
         obj = should_resolve.pop
@@ -33,12 +33,12 @@ module CombinePDF
         if obj.is_a?(Hash)
           referenced = obj[:referenced_object]
           if referenced && referenced.any?
-            tmp = resolved[referenced.object_id] || existing[referenced]
+            tmp = resolved[referenced.object_id] || existing[referenced.object_id]
             if tmp
               obj[:referenced_object] = tmp
             else
               resolved[obj.object_id] = referenced
-              existing[referenced] = referenced
+              existing[referenced.object_id] = referenced
               should_resolve << referenced
               @objects << referenced
             end


### PR DESCRIPTION
This prevents an error when adding a lot of PDFs together, which only seems to manifest when using Sidekiq. I only hit the error when combining over 140 PDFs and I still don't know quite what the root cause was apart from the `eql?` method got into a recursive loop when comparing the incoming objects with the existing keys. Running in the Rails console worked fine. Whatever the ultimate issue, this fixes it.

```
SystemStackError: stack level too deep
- 286 non-project frames
1
File "/app/vendor/bundle/ruby/2.2.0/gems/combine_pdf-0.2.31/lib/combine_pdf/pdf_protected.rb" line 36 in eql?
2
File "/app/vendor/bundle/ruby/2.2.0/gems/combine_pdf-0.2.31/lib/combine_pdf/pdf_protected.rb" line 36 in eql?
3
File "/app/vendor/bundle/ruby/2.2.0/gems/combine_pdf-0.2.31/lib/combine_pdf/pdf_protected.rb" line 36 in eql?
4
File "/app/vendor/bundle/ruby/2.2.0/gems/combine_pdf-0.2.31/lib/combine_pdf/pdf_protected.rb" line 36 in eql?
```
