### PR TITLE
Check object[:Contents] to verify that it is a Hash

### DIFF
--- a/lib/combine_pdf/renderer.rb
+++ b/lib/combine_pdf/renderer.rb
@@ -107,7 +107,7 @@ module CombinePDF
         end
       end
       # remove extra page references.
-      object[:Contents].delete(is_reference_only: true, referenced_object: { indirect_reference_id: 0, raw_stream_content: '' }) if object[:Type] == :Page
+      object[:Contents].delete(is_reference_only: true, referenced_object: { indirect_reference_id: 0, raw_stream_content: '' }) if object[:Type] == :Page && object[:Contents].is_a?(Hash)
       # correct stream length, if the object is a stream.
       object[:Length] = object[:raw_stream_content].bytesize if object[:raw_stream_content]
 


### PR DESCRIPTION
An issue can occur when attempting to perform the **Hash** method `delete` on `object[:Contents]` when `object[:Contents]` is actually not a **Hash**.

When attempting to merge multiple PDFs together that were originally converted from RTF using Microsoft Word, there appears to be some instances where `object[:Contents]` ends up as **Nil**, not as a **Hash**. Adding a check to make sure that `object[:Contents]` is a **Hash** allows it to execute the delete method.

While this doesn't appear to have broken anything with testing, an alternate fix would be the make sure that `object[:Contents]` is not **Nil** before performing the deletion; however this fix may cause issues down the line if `object[:Contents]` happens to be another type that supports `delete`, such as **Array**.
