### PR TITLE
Small floating point numbers cause invalid PDF errors

### DIFF
--- a/combine_pdf.gemspec
+++ b/combine_pdf.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "minitest"
 end

--- a/lib/combine_pdf/renderer.rb
+++ b/lib/combine_pdf/renderer.rb
@@ -20,8 +20,10 @@ module CombinePDF
         return format_name_to_pdf object
       elsif object.is_a?(Array)
         return format_array_to_pdf object
-      elsif object.is_a?(Numeric) || object.is_a?(TrueClass) || object.is_a?(FalseClass)
+      elsif object.is_a?(Integer) || object.is_a?(TrueClass) || object.is_a?(FalseClass)
         return object.to_s
+      elsif object.is_a?(Numeric) # Float or other non-integer
+        return sprintf('%f', object)
       elsif object.is_a?(Hash)
         return format_hash_to_pdf object
       else

--- a/lib/combine_pdf/renderer.rb
+++ b/lib/combine_pdf/renderer.rb
@@ -49,7 +49,7 @@ module CombinePDF
       obj_bytes = object.bytes.to_a
       # object.force_encoding(Encoding::ASCII_8BIT)
       if object.length == 0 || obj_bytes.min <= 31 || obj_bytes.max >= 127 # || (obj_bytes[0] != 68  object.match(/[^D\:\d\+\-Z\']/))
-        # A hexadecimal string shall be written as a sequence of hexadecimal digits (0–9 and either A–F or a–f)
+        # A hexadecimal string shall be written as a sequence of hexadecimal digits (0-9 and either A-F or a-f)
         # encoded as ASCII characters and enclosed within angle brackets (using LESS-THAN SIGN (3Ch) and GREATER- THAN SIGN (3Eh)).
         "<#{object.unpack('H*')[0]}>".force_encoding(Encoding::ASCII_8BIT)
       else

--- a/test/combine_pdf/renderer_test.rb
+++ b/test/combine_pdf/renderer_test.rb
@@ -1,0 +1,22 @@
+require 'bundler/setup'
+require 'minitest/autorun'
+require 'combine_pdf/renderer'
+
+class CombinePDFRendererTest < Minitest::Test
+
+  class TestRenderer
+    include CombinePDF::Renderer
+
+    def test_object(object)
+      object_to_pdf(object)
+    end
+  end
+
+  def test_numeric_array_to_pdf
+    input = [1.234567, 0.000054, 5, -0.000099]
+    expected = "[1.234567 0.000054 5 -0.000099]".force_encoding('BINARY')
+    actual = TestRenderer.new.test_object(input)
+
+    assert_equal(expected, actual)
+  end
+end


### PR DESCRIPTION
When a number in the parsed source is smaller than 0.0001 then its default
string representation changes to exponential notation such as "1.23e-05".
This format is not recognized as a numeric value so we need to ensure it
remains as regular decimal notation.