### PR TITLE
Update buttom to bottom

### DIFF
--- a/lib/combine_pdf/api.rb
+++ b/lib/combine_pdf/api.rb
@@ -140,7 +140,7 @@ module CombinePDF
   # this function enables plug-ins to expend the font functionality of CombinePDF.
   #
   # font_name:: a Symbol with the name of the font. if the fonts exists in the library, it will be overwritten!
-  # font_metrics:: a Hash of font metrics, of the format char => {wx: char_width, boundingbox: [left_x, buttom_y, right_x, top_y]} where char == character itself (i.e. " " for space). The Hash should contain a special value :missing for the metrics of missing characters. an optional :wy might be supported in the future, for up to down fonts.
+  # font_metrics:: a Hash of font metrics, of the format char => {wx: char_width, boundingbox: [left_x, bottom_y, right_x, top_y]} where char == character itself (i.e. " " for space). The Hash should contain a special value :missing for the metrics of missing characters. an optional :wy might be supported in the future, for up to down fonts.
   # font_pdf_object:: a Hash in the internal format recognized by CombinePDF, that represents the font object.
   # font_cmap:: a CMap dictionary Hash) which maps unicode characters to the hex CID for the font (i.e. {"a" => "61", "z" => "7a" }).
   def register_font(font_name, font_metrics, font_pdf_object, font_cmap = nil)

--- a/lib/combine_pdf/fonts.rb
+++ b/lib/combine_pdf/fonts.rb
@@ -100,7 +100,7 @@ module CombinePDF
 
     # adds a correctly formatted font object to the font library.
     # font_name:: a Symbol with the name of the font. if the fonts name exists, the font will be overwritten!
-    # font_metrics:: a Hash of ont metrics, of the format char => {wx: char_width, boundingbox: [left_x, buttom_y, right_x, top_y]} where i == character code (i.e. 32 for space). The Hash should contain a special value :missing for the metrics of missing characters. an optional :wy will be supported in the future, for up to down fonts.
+    # font_metrics:: a Hash of ont metrics, of the format char => {wx: char_width, boundingbox: [left_x, bottom_y, right_x, top_y]} where i == character code (i.e. 32 for space). The Hash should contain a special value :missing for the metrics of missing characters. an optional :wy will be supported in the future, for up to down fonts.
     # font_pdf_object:: a Hash in the internal format recognized by CombinePDF, that represents the font object.
     # font_cmap:: a CMap dictionary Hash) which maps unicode characters to the hex CID for the font (i.e. {"a" => "61", "z" => "7a" }).
     def register_font(font_name, font_metrics, font_pdf_object, font_cmap = nil)

--- a/lib/combine_pdf/page_methods.rb
+++ b/lib/combine_pdf/page_methods.rb
@@ -151,11 +151,11 @@ module CombinePDF
     # properties:: a Hash of box properties.
     # the symbols and values in the properties Hash could be any or all of the following:
     # x:: the left position of the box.
-    # y:: the BUTTOM position of the box.
+    # y:: the BOTTOM position of the box.
     # width:: the width/length of the box. negative values will be computed from edge of page. defaults to 0 (end of page).
     # height:: the height of the box. negative values will be computed from edge of page. defaults to 0 (end of page).
     # text_align:: symbol for horizontal text alignment, can be ":center" (default), ":right", ":left"
-    # text_valign:: symbol for vertical text alignment, can be ":center" (default), ":top", ":buttom"
+    # text_valign:: symbol for vertical text alignment, can be ":center" (default), ":top", ":bottom"
     # text_padding:: a Float between 0 and 1, setting the padding for the text. defaults to 0.05 (5%).
     # font:: a registered font name or an Array of names. defaults to ":Helvetica". The 14 standard fonts names are:
     # - :"Times-Roman"
@@ -244,8 +244,8 @@ module CombinePDF
         half_radius = (radius.to_f / 2).round 4
         ## set starting point
         box_stream << "#{options[:x] + radius} #{options[:y]} m\n"
-        ## buttom and right corner - first line and first corner
-        box_stream << "#{options[:x] + options[:width] - radius} #{options[:y]} l\n" # buttom
+        ## bottom and right corner - first line and first corner
+        box_stream << "#{options[:x] + options[:width] - radius} #{options[:y]} l\n" # bottom
         if options[:box_radius] != 0 # make first corner, if not straight.
           box_stream << "#{options[:x] + options[:width] - half_radius} #{options[:y]} "
           box_stream << "#{options[:x] + options[:width]} #{options[:y] + half_radius} "
@@ -265,7 +265,7 @@ module CombinePDF
           box_stream << "#{options[:x]} #{options[:y] + options[:height] - half_radius} "
           box_stream << "#{options[:x]} #{options[:y] + options[:height] - radius} c\n"
         end
-        ## left and buttom-left corner
+        ## left and bottom-left corner
         box_stream << "#{options[:x]} #{options[:y] + radius} l\n"
         if options[:box_radius] != 0
           box_stream << "#{options[:x]} #{options[:y] + half_radius} "
@@ -287,7 +287,7 @@ module CombinePDF
       end
       contents << box_stream
 
-      # reset x,y by text alignment - x,y are calculated from the buttom left
+      # reset x,y by text alignment - x,y are calculated from the bottom left
       # each unit (1) is 1/72 Inch
       # create text stream
       text_stream = ''

--- a/lib/combine_pdf/pdf_public.rb
+++ b/lib/combine_pdf/pdf_public.rb
@@ -358,9 +358,9 @@ module CombinePDF
     #
     # options:: a Hash of options setting the behavior and format of the page numbers:
     # - :number_format a string representing the format for page number. defaults to ' - %s - ' (allows for letter numbering as well, such as "a", "b"...).
-    # - :location an Array containing the location for the page numbers, can be :top, :buttom, :top_left, :top_right, :bottom_left, :bottom_right or :center (:center == full page). defaults to [:top, :buttom].
+    # - :location an Array containing the location for the page numbers, can be :top, :bottom, :top_left, :top_right, :bottom_left, :bottom_right or :center (:center == full page). defaults to [:top, :bottom].
     # - :start_at an Integer that sets the number for first page number. also accepts a letter ("a") for letter numbering. defaults to 1.
-    # - :margin_from_height a number (PDF points) for the top and buttom margins. defaults to 45.
+    # - :margin_from_height a number (PDF points) for the top and bottom margins. defaults to 45.
     # - :margin_from_side a number (PDF points) for the left and right margins. defaults to 15.
     # - :page_range a range of pages to be numbered (i.e. (2..-1) ) defaults to all the pages (nil). Remember to set the :start_at to the correct value.
     # the options Hash can also take all the options for {Page_Methods#textbox}.


### PR DESCRIPTION
Hi @boazsegev thanks for the great library. We're starting to use it to put some dynamic pdf content into a template we designed. It's great.

I noticed when reading through the documentation there were references to "buttom". I believe these should all be "bottom" instead.

This is just a simple pull request that finds buttom and replaces with bottom. Thanks again for the gem.