### PR TITLE
[FIX] Under Some Conditions the indirect_reference_id And indirect_generation_number Seem Incorrect

### DIFF
--- a/lib/combine_pdf/parser.rb
+++ b/lib/combine_pdf/parser.rb
@@ -623,7 +623,9 @@ module CombinePDF
                   o = nil
                 else
                   o[:referenced_object] = obj_dir[[o[:indirect_reference_id], o[:indirect_generation_number]]]
-                  warn "Couldn't connect reference for #{o}" if o[:referenced_object].nil? && (o[:indirect_reference_id] + o[:indirect_generation_number] != 0)
+                  warn "Couldn't connect reference for #{o}" if o[:referenced_object].nil? &&
+                    o[:indirect_reference_id].is_a?(Numeric) && o[:indirect_generation_number].is_a?(Numeric) &&
+                    (o[:indirect_reference_id] + o[:indirect_generation_number] != 0)
                   o.delete :indirect_reference_id
                   o.delete :indirect_generation_number
                   o = (o[:referenced_object] && o[:referenced_object][:indirect_without_dictionary]) || o


### PR DESCRIPTION
### Description

We're having a project that is about to upgrade from `0.2.x` to `1.x.x`, but we encountered some of our PDFs failed to parse in our test suites. I'm not familiar with PDF encode/decode, so I made a patch to make sure it works correctly as before. Hope this is the proper way to modify it, thanks for the review.

### Issues Screenshots

<img width="593" alt="Screenshot 2019-06-20 18 17 10" src="https://user-images.githubusercontent.com/2749593/59843491-40e50980-938b-11e9-934e-a315d0072979.png">

![Screenshot 2019-06-20 18 31 52](https://user-images.githubusercontent.com/2749593/59843530-535f4300-938b-11e9-8454-f219102f7304.png)
