### PR TITLE
Add `skip_rename_anchor` to PDF object

### DIFF
--- a/lib/combine_pdf/api.rb
+++ b/lib/combine_pdf/api.rb
@@ -8,7 +8,7 @@ module CombinePDF
   def load(file_name = '', options = {})
     raise TypeError, "couldn't parse data, expecting type String" unless file_name.is_a?(String) || file_name.is_a?(Pathname)
     return PDF.new if file_name == ''
-    PDF.new(PDFParser.new(IO.read(file_name, mode: 'rb').force_encoding(Encoding::ASCII_8BIT), options))
+    PDF.new(PDFParser.new(IO.read(file_name, mode: 'rb').force_encoding(Encoding::ASCII_8BIT), options), skip_rename_anchor: options[:skip_rename_anchor])
   end
 
   # creats a new PDF object.
@@ -37,7 +37,7 @@ module CombinePDF
   # data:: is a string that represents the content of a PDF file.
   def parse(data, options = {})
     raise TypeError, "couldn't parse and data, expecting type String" unless data.is_a? String
-    PDF.new(PDFParser.new(data, options))
+    PDF.new(PDFParser.new(data, options), skip_rename_anchor: options[:skip_rename_anchor])
   end
 
   # makes a PDFWriter object

--- a/lib/combine_pdf/pdf_protected.rb
+++ b/lib/combine_pdf/pdf_protected.rb
@@ -198,8 +198,10 @@ module CombinePDF
           if pos.is_a? Array
             next if resolved.include?(pos.object_id)
             if pos[0].is_a? String
+              pos = pos.group_by.with_index{|_, i| i/2 }.values.sort_by(&:first).flatten(1) if @skip_rename_anchor
               (pos.length / 2).times do |i|
-                dic << (pos[i * 2].clear << base.next!)
+                @skip_rename_anchor ? dic << pos[i * 2] : dic << (pos[i * 2].clear << base.next!)
+
                 pos[(i * 2) + 1][0] = {is_reference_only: true, referenced_object: pages[pos[(i * 2) + 1][0]]} if(pos[(i * 2) + 1].is_a?(Array) && pos[(i * 2) + 1][0].is_a?(Numeric))
                 dic << (pos[(i * 2) + 1].is_a?(Array) ? { is_reference_only: true, referenced_object: { indirect_without_dictionary: pos[(i * 2) + 1] } } : pos[(i * 2) + 1])
                 # dic << pos[(i * 2) + 1]

--- a/lib/combine_pdf/pdf_public.rb
+++ b/lib/combine_pdf/pdf_public.rb
@@ -86,8 +86,10 @@ module CombinePDF
     attr_reader :outlines
     # Access the Names PDF object Hash (or reference). Use with care.
     attr_reader :names
+    # For skip reset anchors' name
+    attr_reader :skip_rename_anchor
 
-    def initialize(parser = nil)
+    def initialize(parser = nil, options = {})
       # default before setting
       @objects = []
       @version = 0
@@ -104,6 +106,10 @@ module CombinePDF
       @names = parser.names_object || {}
       @forms_data = parser.forms_object || {}
       @outlines = parser.outlines_object || {}
+
+      # Default is to change all anchors' name, but can be skipped by skip_rename_anchor option.
+      @skip_rename_anchor = options[:skip_rename_anchor] || false
+
       # rebuild the catalog, to fix wkhtmltopdf's use of static page numbers
       rebuild_catalog
 
@@ -304,6 +310,7 @@ module CombinePDF
     def insert(location, data)
       pages_to_add = nil
       if data.is_a? PDF
+        @skip_rename_anchor = data.skip_rename_anchor
         @version = [@version, data.version].max
         pages_to_add = data.pages
         actual_value(@names ||= {}.dup).update data.names, &HASH_MERGE_NEW_NO_PAGE


### PR DESCRIPTION
Allow user to decide resetting anchor name or not.