### PR TITLE
Allow user to preserve PDF names

### DIFF
--- a/lib/combine_pdf/api.rb
+++ b/lib/combine_pdf/api.rb
@@ -8,7 +8,7 @@ module CombinePDF
   def load(file_name = '', options = {})
     raise TypeError, "couldn't parse data, expecting type String" unless file_name.is_a?(String) || file_name.is_a?(Pathname)
     return PDF.new if file_name == ''
-    PDF.new(PDFParser.new(IO.read(file_name, mode: 'rb').force_encoding(Encoding::ASCII_8BIT), options))
+    PDF.new(PDFParser.new(IO.read(file_name, mode: 'rb').force_encoding(Encoding::ASCII_8BIT), options), preserve_names: options[:preserve_names])
   end
 
   # creats a new PDF object.
@@ -37,7 +37,7 @@ module CombinePDF
   # data:: is a string that represents the content of a PDF file.
   def parse(data, options = {})
     raise TypeError, "couldn't parse and data, expecting type String" unless data.is_a? String
-    PDF.new(PDFParser.new(data, options))
+    PDF.new(PDFParser.new(data, options), preserve_names: options[:preserve_names])
   end
 
   # makes a PDFWriter object

--- a/lib/combine_pdf/pdf_protected.rb
+++ b/lib/combine_pdf/pdf_protected.rb
@@ -198,8 +198,16 @@ module CombinePDF
           if pos.is_a? Array
             next if resolved.include?(pos.object_id)
             if pos[0].is_a? String
+
+              # Names should sorted in ascending,
+              # so re-sort is needed if preserving names.
+              pos = pos.group_by.with_index{|_, i| i/2 }.values.sort_by(&:first).flatten(1) if @preserve_names
+
               (pos.length / 2).times do |i|
-                dic << (pos[i * 2].clear << base.next!)
+                # According preserve_names value decide changing or not
+                pos[i * 2].clear << base.next! unless @preserve_names
+                dic << pos[i * 2]
+
                 pos[(i * 2) + 1][0] = {is_reference_only: true, referenced_object: pages[pos[(i * 2) + 1][0]]} if(pos[(i * 2) + 1].is_a?(Array) && pos[(i * 2) + 1][0].is_a?(Numeric))
                 dic << (pos[(i * 2) + 1].is_a?(Array) ? { is_reference_only: true, referenced_object: { indirect_without_dictionary: pos[(i * 2) + 1] } } : pos[(i * 2) + 1])
                 # dic << pos[(i * 2) + 1]

--- a/lib/combine_pdf/pdf_public.rb
+++ b/lib/combine_pdf/pdf_public.rb
@@ -86,8 +86,10 @@ module CombinePDF
     attr_reader :outlines
     # Access the Names PDF object Hash (or reference). Use with care.
     attr_reader :names
+    # For preserve original names
+    attr_reader :preserve_names
 
-    def initialize(parser = nil)
+    def initialize(parser = nil, options = {})
       # default before setting
       @objects = []
       @version = 0
@@ -104,6 +106,10 @@ module CombinePDF
       @names = parser.names_object || {}
       @forms_data = parser.forms_object || {}
       @outlines = parser.outlines_object || {}
+
+      # Default is to change all names
+      @preserve_names = options[:preserve_names] || false
+
       # rebuild the catalog, to fix wkhtmltopdf's use of static page numbers
       rebuild_catalog
 
@@ -304,6 +310,7 @@ module CombinePDF
     def insert(location, data)
       pages_to_add = nil
       if data.is_a? PDF
+        @preserve_names = data.preserve_names
         @version = [@version, data.version].max
         pages_to_add = data.pages
         actual_value(@names ||= {}.dup).update data.names, &HASH_MERGE_NEW_NO_PAGE


### PR DESCRIPTION
Hi

We use wkhtmltopdf to convert PDF, it provides `--dump-outline` to export a XML that
contains document outline and PDF detination names.

wkhtmltopdf allows special link destination that matches PDF destination names to be
converted as PDF links. (ie __WKANCHOR_*), which allows generating custom ToC page.

We use CombinePDF to merge the toc pdf and content pdf, but we found the linking feature won't work
due to CombinePDF automatically rename named destinations.

This is a patch that add a new option `preserve_names`, to allow user to merge two PDF without renaming destinations.

Thanks