### PR TITLE
CHANGELOG: Mark v1.0.17 yanked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 #### Change log v.1.0.17
 
+NB: yanked from RubyGems.org.
+
 **Fix**: fixed issue where nested structure equality tests might provide false positives, resulting in lost data (issue #166) - credit to @cschilbe (Conrad Schilbe).
 
 #### Change log v.1.0.16


### PR DESCRIPTION
This PR amends the Changelog, to reflect the absence of 1.0.17 in RubyGems.org 

https://rubygems.org/gems/combine_pdf