### PR TITLE
Fix: TypeError: can't dup NilClass

### DIFF
--- a/lib/combine_pdf/parser.rb
+++ b/lib/combine_pdf/parser.rb
@@ -579,7 +579,7 @@ module CombinePDF
                 catalogs[:ProcSet][:referenced_object].uniq!
               else
                 catalogs[:ProcSet] = { is_reference_only: true }.dup
-                catalogs[:ProcSet][:referenced_object] = catalogs[:ProcSet][:referenced_object].dup
+                catalogs[:ProcSet][:referenced_object] = inheritance_hash[:ProcSet][:referenced_object].dup
               end
             end
             # (catalogs[:ColorSpace] ||= {}).update(inheritance_hash[:ColorSpace], &HASH_UPDATE_PROC_FOR_OLD) if inheritance_hash[:ColorSpace]

--- a/lib/combine_pdf/parser.rb
+++ b/lib/combine_pdf/parser.rb
@@ -579,7 +579,7 @@ module CombinePDF
                 catalogs[:ProcSet][:referenced_object].uniq!
               else
                 catalogs[:ProcSet] = { is_reference_only: true }.dup
-                catalogs[:ProcSet][:referenced_object] = inheritance_hash[:ProcSet][:referenced_object].dup
+                catalogs[:ProcSet][:referenced_object] = []
               end
             end
             # (catalogs[:ColorSpace] ||= {}).update(inheritance_hash[:ColorSpace], &HASH_UPDATE_PROC_FOR_OLD) if inheritance_hash[:ColorSpace]


### PR DESCRIPTION
In the instance where the catalogs variable does not have a :ProcSet
key, the code generates a new hash and assigns it to that key.  It then
tries to dup the value in that new hash for a key that does not exist.
Other code above uses the inheritance_hash to dup when the data does not
exists, and this follows that same flow.

EDIT: On further processing, when trying to create pages from a pdf loaded using inheritance_hash, it will raise an error.  Simply using an empty array gets past the error and allows you to save individual pages.