### PR TITLE
Add matrix as a dependency for Ruby 3.1 compatibility

### DIFF
--- a/combine_pdf.gemspec
+++ b/combine_pdf.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'ruby-rc4', '>= 0.1.5'
+  spec.add_runtime_dependency 'matrix'
 
   # spec.add_development_dependency "bundler", ">= 1.7"
   spec.add_development_dependency "rake", ">= 12.3.3"


### PR DESCRIPTION
It used to be a default gem shipped with Ruby, but will no longer be the case in 3.1.

See https://bugs.ruby-lang.org/issues/17873 for more context.