### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/combine_pdf.gemspec
+++ b/combine_pdf.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/boazsegev/combine_pdf"
   spec.license       = "MIT"
 
+  spec.metadata      = { 'rubygems_mfa_required' => 'true' }
+
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/

---

I've seen that there is not a clear preference of `"` above `'`, so I'm using `'` 