### PR TITLE
Add guard to prevent nil error while parsing octal notation

### DIFF
--- a/lib/combine_pdf/parser.rb
+++ b/lib/combine_pdf/parser.rb
@@ -323,8 +323,8 @@ module CombinePDF
                 str << 12
               when 48..57 # octal notation for byte?
                 rep -= 48
-                rep = (rep << 3) + (str_bytes.shift-48) if str_bytes[0].between?(48, 57)
-                rep = (rep << 3) + (str_bytes.shift-48) if str_bytes[0].between?(48, 57) && (((rep << 3) + (str_bytes[0] - 48)) <= 255)
+                rep = (rep << 3) + (str_bytes.shift-48) if str_bytes[0]&.between?(48, 57)
+                rep = (rep << 3) + (str_bytes.shift-48) if str_bytes[0]&.between?(48, 57) && (((rep << 3) + (str_bytes[0] - 48)) <= 255)
                 str << rep
               when 10 # new line, ignore
                 str_bytes.shift if str_bytes[0] == 13


### PR DESCRIPTION
While parsing a PDF, we ran into an issue where the the following error was raised:

```
NoMethodError: undefined method between? for nil:NilClass
```

We tracked it down to this line in the `_parse_` method of `PDFParser`:

```
rep = (rep << 3) + (str_bytes.shift-48) if str_bytes[0].between?(48, 57)
```

It turns out there is potentially an error scenario while looping until `str_bytes` is empty where accessing `str_bytes[0]` would be a `nil` value. We just added the safe navigation operator which was added in Ruby 2.3. If this project is still supporting older rubies we can amend the commit.