### PR TITLE
docs: correct wrong PR number on CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Change log v.1.0.25 (2023-12-19)
 
-**Fix**: possible improve memory usage. Credit to @denislavski (Denislav Naydenov) for opening PR #223 and suggesting this change.
+**Fix**: possible improve memory usage. Credit to @denislavski (Denislav Naydenov) for opening PR #233 and suggesting this change.
 
 #### Change log v.1.0.24 (2023-10-19)
 


### PR DESCRIPTION
The PR number that lead to version 1.0.25 is wrong. The right number should be #233 (because #223 is an unrelated issue).