### PR TITLE
Add compatibility with --enable-frozen-string-literal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
+        rubyopt: [""]
+        include:
+          - ruby: "3.3"
+            rubyopt: "--enable-frozen-string-literal --debug-frozen-string-literal"
 
     steps:
       - name: Checkout code
@@ -25,4 +29,4 @@ jobs:
         run: bundle lock
 
       - name: Run tests
-        run: bundle exec rake test
+        run: bundle exec rake test RUBYOPT="${{ matrix.rubyopt }}"

--- a/lib/combine_pdf.rb
+++ b/lib/combine_pdf.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
 
 require 'zlib'
 require 'securerandom'

--- a/lib/combine_pdf/api.rb
+++ b/lib/combine_pdf/api.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
 
 module CombinePDF
   module_function

--- a/lib/combine_pdf/basic_writer.rb
+++ b/lib/combine_pdf/basic_writer.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
 ########################################################
 ## Thoughts from reading the ISO 32000-1:2008
 ## this file is part of the CombinePDF library and the code

--- a/lib/combine_pdf/decrypt.rb
+++ b/lib/combine_pdf/decrypt.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
 ########################################################
 ## Thoughts from reading the ISO 32000-1:2008
 ## this file is part of the CombinePDF library and the code
@@ -137,7 +138,7 @@ module CombinePDF
       object_key = @key.dup
       object_key << [encrypted_id].pack('i')[0..2]
       object_key << [encrypted_generation].pack('i')[0..1]
-      object_key << 'sAlT'.force_encoding(Encoding::ASCII_8BIT)
+      object_key << 'sAlT'.b
       key_length = object_key.length < 16 ? object_key.length : 16
 
       begin

--- a/lib/combine_pdf/exceptions.rb
+++ b/lib/combine_pdf/exceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CombinePDF
   class EncryptionError < StandardError
   end

--- a/lib/combine_pdf/filter.rb
+++ b/lib/combine_pdf/filter.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
 ########################################################
 ## Thoughts from reading the ISO 32000-1:2008
 ## this file is part of the CombinePDF library and the code

--- a/lib/combine_pdf/fonts.rb
+++ b/lib/combine_pdf/fonts.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
 ########################################################
 ## Thoughts from reading the ISO 32000-1:2008
 ## this file is part of the CombinePDF library and the code

--- a/lib/combine_pdf/page_methods.rb
+++ b/lib/combine_pdf/page_methods.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
 ########################################################
 ## Thoughts from reading the ISO 32000-1:2008
 ## this file is part of the CombinePDF library and the code
@@ -214,7 +215,7 @@ module CombinePDF
       options[:text_padding] = 0 if options[:text_padding].to_f >= 1
 
       # create box stream
-      box_stream = ''
+      box_stream = +''
       # set graphic state for box
       if options[:box_color] || (options[:border_width].to_i > 0 && options[:border_color])
         # compute x and y position for text
@@ -290,7 +291,7 @@ module CombinePDF
       # reset x,y by text alignment - x,y are calculated from the bottom left
       # each unit (1) is 1/72 Inch
       # create text stream
-      text_stream = ''
+      text_stream = +''
       if !text.to_s.empty? && options[:font_size] != 0 && (options[:font_color] || options[:stroke_color])
         # compute x and y position for text
         x = options[:x] + (options[:width] * options[:text_padding])
@@ -679,7 +680,7 @@ module CombinePDF
       insert_content 'Q'
 
       # Prep content
-      @contents = ''
+      @contents = +''
       insert_content @contents
       @contents
     end

--- a/lib/combine_pdf/parser.rb
+++ b/lib/combine_pdf/parser.rb
@@ -262,7 +262,7 @@ module CombinePDF
         ##########################################
         elsif @scanner.scan(/\(/)
           # warn "Found a literal string"
-          str = ''.force_encoding(Encoding::ASCII_8BIT)
+          str = ''.b
           count = 1
           while count > 0 && @scanner.rest?
             scn = @scanner.scan_until(/[\(\)]/)
@@ -379,7 +379,7 @@ module CombinePDF
           length = 0 if(length < 0)
           length -= 1 if(@scanner.string[old_pos + length - 1] == "\n") 
           length -= 1 if(@scanner.string[old_pos + length - 1] == "\r") 
-          str = (length > 0) ? @scanner.string.slice(old_pos, length) : ''
+          str = (length > 0) ? @scanner.string.slice(old_pos, length) : +''
 
           # warn "CombinePDF parser: detected Stream #{str.length} bytes long #{str[0..3]}...#{str[-4..-1]}"
 

--- a/lib/combine_pdf/pdf_protected.rb
+++ b/lib/combine_pdf/pdf_protected.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
 ########################################################
 ## Thoughts from reading the ISO 32000-1:2008
 ## this file is part of the CombinePDF library and the code
@@ -186,6 +187,7 @@ module CombinePDF
     POSSIBLE_NAME_TREES = [:Dests, :AP, :Pages, :IDS, :Templates, :URLS, :JavaScript, :EmbeddedFiles, :AlternatePresentations, :Renditions].to_set.freeze
 
     def rebuild_names(name_tree = nil, base = 'CombinePDF_0000000')
+      base = +base
       if name_tree
         return nil unless name_tree.is_a?(Hash)
         name_tree = name_tree[:referenced_object] || name_tree

--- a/lib/combine_pdf/pdf_public.rb
+++ b/lib/combine_pdf/pdf_public.rb
@@ -1,5 +1,6 @@
 # -*- encoding : utf-8 -*-
-########################################################
+## frozen_string_literal: true
+#######################################################
 ## Thoughts from reading the ISO 32000-1:2008
 ## this file is part of the CombinePDF library and the code
 ## is subject to the same license.
@@ -93,7 +94,7 @@ module CombinePDF
       @version = 0
       @viewer_preferences = {}
       @info = {}
-      parser ||= PDFParser.new('')
+      parser ||= PDFParser.new(+'')
       raise TypeError, "initialization error, expecting CombinePDF::PDFParser or nil, but got #{parser.class.name}" unless parser.is_a? PDFParser
       @objects = parser.parse
 
@@ -216,7 +217,7 @@ module CombinePDF
       # when finished, remove the numbering system and keep only pointers
       remove_old_ids
       # output the pdf stream
-      out.join("\n".force_encoding(Encoding::ASCII_8BIT)).force_encoding(Encoding::ASCII_8BIT)
+      out.join("\n").force_encoding(Encoding::ASCII_8BIT)
     end
 
     # this method returns all the pages cataloged in the catalog.

--- a/lib/combine_pdf/renderer.rb
+++ b/lib/combine_pdf/renderer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CombinePDF
   ################################################################
   ## These are common functions, used within the different classes
@@ -123,12 +124,12 @@ module CombinePDF
       # if the object is not a simple object, it is a dictionary
       # A dictionary shall be written as a sequence of key-value pairs enclosed in double angle brackets (<<...>>)
       # (using LESS-THAN SIGNs (3Ch) and GREATER-THAN SIGNs (3Eh)).
-      out << "<<\n".force_encoding(Encoding::ASCII_8BIT)
+      out << "<<\n".b
       object.each do |key, value|
         out << "#{object_to_pdf key} #{object_to_pdf value}\n".force_encoding(Encoding::ASCII_8BIT) unless PDF::PRIVATE_HASH_KEYS.include? key
       end
       object.delete :Length
-      out << '>>'.force_encoding(Encoding::ASCII_8BIT)
+      out << '>>'.b
       out << "\nstream\n#{object[:raw_stream_content]}\nendstream".force_encoding(Encoding::ASCII_8BIT) if object[:raw_stream_content]
       out << "\nendobj\n" if object[:indirect_reference_id]
       out.join.force_encoding(Encoding::ASCII_8BIT)

--- a/lib/combine_pdf/version.rb
+++ b/lib/combine_pdf/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CombinePDF
-  VERSION = '1.0.26'.freeze
+  VERSION = '1.0.26'
 end

--- a/test/combine_pdf/renderer_test.rb
+++ b/test/combine_pdf/renderer_test.rb
@@ -12,7 +12,7 @@ class CombinePDFRendererTest < Minitest::Test
 
   def test_numeric_array_to_pdf
     input = [1.234567, 0.000054, 5, -0.000099]
-    expected = "[1.234567 0.000054 5 -0.000099]".force_encoding('BINARY')
+    expected = "[1.234567 0.000054 5 -0.000099]".b
     actual = TestRenderer.new.test_object(input)
 
     assert_equal(expected, actual)


### PR DESCRIPTION
Fix: https://github.com/boazsegev/combine_pdf/pull/168
Ref: https://bugs.ruby-lang.org/issues/20205

Ruby 3.4 will emit deprecation warnings when mutating string literals, and a future version is likely to make frozen string literals the default.

cc @boazsegev 