### PR TITLE
Make `CombinePDF.parse` work with frozen strings

### DIFF
--- a/lib/combine_pdf/parser.rb
+++ b/lib/combine_pdf/parser.rb
@@ -41,7 +41,7 @@ module CombinePDF
     # string:: the data to be parsed, as a String object.
     def initialize(string, options = {})
       raise TypeError, "couldn't parse data, expecting type String" unless string.is_a? String
-      @string_to_parse = string.force_encoding(Encoding::ASCII_8BIT)
+      @string_to_parse = (+string).force_encoding(Encoding::ASCII_8BIT)
       @literal_strings = [].dup
       @hex_strings = [].dup
       @streams = [].dup
@@ -377,8 +377,8 @@ module CombinePDF
           end
           length = @scanner.pos - (old_pos + 9)
           length = 0 if(length < 0)
-          length -= 1 if(@scanner.string[old_pos + length - 1] == "\n") 
-          length -= 1 if(@scanner.string[old_pos + length - 1] == "\r") 
+          length -= 1 if(@scanner.string[old_pos + length - 1] == "\n")
+          length -= 1 if(@scanner.string[old_pos + length - 1] == "\r")
           str = (length > 0) ? @scanner.string.slice(old_pos, length) : +''
 
           # warn "CombinePDF parser: detected Stream #{str.length} bytes long #{str[0..3]}...#{str[-4..-1]}"

--- a/test/combine_pdf/parse_test.rb
+++ b/test/combine_pdf/parse_test.rb
@@ -1,0 +1,11 @@
+require 'minitest/autorun'
+
+describe 'CombinePDF.parse' do
+  let(:pdf_string) { CombinePDF.load('test/fixtures/files/sample_pdf.pdf').to_pdf.freeze }
+
+  subject { CombinePDF.parse(pdf_string) }
+
+  it 'parses the PDF' do
+    assert_instance_of CombinePDF::PDF, subject
+  end
+end


### PR DESCRIPTION
Fixes calling `CombinePDF.parse` with a frozen string. Currently, `CombinePDF.parse(some_frozen_pdf_string)` results in a `FrozenError.`