### PR TITLE
Support Ruby 4 frozen string literals

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "4.0"]
         rubyopt: [""]
         include:
-          - ruby: "3.3"
+          - ruby: "4.0"
+            rubyopt: "-W:deprecated"
+          - ruby: "4.0"
             rubyopt: "--enable-frozen-string-literal --debug-frozen-string-literal"
 
     steps:

--- a/lib/combine_pdf/parser.rb
+++ b/lib/combine_pdf/parser.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
 ########################################################
 ## Thoughts from reading the ISO 32000-1:2008
 ## this file is part of the CombinePDF library and the code
@@ -41,7 +42,7 @@ module CombinePDF
     # string:: the data to be parsed, as a String object.
     def initialize(string, options = {})
       raise TypeError, "couldn't parse data, expecting type String" unless string.is_a? String
-      @string_to_parse = (string.frozen? ? string.dup : string).force_encoding(Encoding::ASCII_8BIT)
+      @string_to_parse = string.dup.force_encoding(Encoding::ASCII_8BIT)
       @literal_strings = [].dup
       @hex_strings = [].dup
       @streams = [].dup
@@ -209,7 +210,6 @@ module CombinePDF
     # this is an internal function, but it was left exposed for posible future features.
     def _parse_
       out = []
-      str = ''
       fresh = true
       while @scanner.rest?
         # last ||= 0

--- a/lib/combine_pdf/pdf_public.rb
+++ b/lib/combine_pdf/pdf_public.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-## frozen_string_literal: true
+# frozen_string_literal: true
 #######################################################
 ## Thoughts from reading the ISO 32000-1:2008
 ## this file is part of the CombinePDF library and the code

--- a/test/combine_pdf/parser_test.rb
+++ b/test/combine_pdf/parser_test.rb
@@ -1,0 +1,28 @@
+require 'bundler/setup'
+require 'minitest/autorun'
+require 'combine_pdf'
+
+class CombinePDFParserTest < Minitest::Test
+  def test_parse_does_not_change_source_encoding
+    source = File.read('test/fixtures/files/sample_pdf.pdf', encoding: Encoding::UTF_8)
+
+    CombinePDF.parse(source)
+
+    assert_equal Encoding::UTF_8, source.encoding
+  end
+
+  def test_parse_does_not_mutate_a_chilled_source
+    skip 'chilled string literals need Ruby 3.4+' if RUBY_VERSION < '3.4'
+
+    deprecated = Warning[:deprecated]
+    Warning[:deprecated] = true
+    source = 'a chilled string literal'
+
+    _, warnings = capture_io { CombinePDF::PDFParser.new(source) }
+
+    assert_empty warnings
+    assert_equal Encoding::UTF_8, source.encoding
+  ensure
+    Warning[:deprecated] = deprecated
+  end
+end


### PR DESCRIPTION
Support Ruby 4 frozen string literals

Ruby 4 warns when code mutates chilled strings ahead of freezing string
literals by default. Opt the remaining library files into frozen string
literals, and drop the parser's scratch string, which every branch
reassigns before reading.

Duplicate the source string before forcing its encoding, so parsing no
longer flips a caller's encoding or mutates a chilled literal. The
chilled-literal test enables the deprecation warning itself rather than
relying on the CI flag, since a warning never fails a build.

Exercise Ruby 3.4 and 4.0 in CI, including Ruby 4's deprecated-warning
and frozen-string modes.