### PR TITLE
Fix equal_layers treating differing arrays as equal

### DIFF
--- a/lib/combine_pdf/pdf_protected.rb
+++ b/lib/combine_pdf/pdf_protected.rb
@@ -387,7 +387,7 @@ module CombinePDF
       elsif obj1.is_a? Array
         return false unless obj2.is_a? Array
         return false unless obj1.length == obj2.length
-        (obj1-obj2).any? || (obj2-obj1).any?
+        obj1.each_with_index.all? { |item, i| equal_layers(item, obj2[i], layer) }
       else
         obj1 == obj2
       end

--- a/test/combine_pdf/pdf_protected_test.rb
+++ b/test/combine_pdf/pdf_protected_test.rb
@@ -1,0 +1,14 @@
+require 'bundler/setup'
+require 'minitest/autorun'
+require 'combine_pdf'
+
+class CombinePDFPDFProtectedTest < Minitest::Test
+  def test_to_pdf_keeps_stream_objects_that_share_content_but_differ_in_array_values
+    pdf = CombinePDF.load('test/fixtures/files/shared_stream_form_xobjects.pdf')
+
+    xobjects = CombinePDF.parse(pdf.to_pdf).pages.first[:Resources][:XObject]
+
+    assert_equal [[0, 0, 90, 200], [110, 0, 200, 200]],
+                 xobjects.values_at(:Left, :Right).map { |ref| ref[:referenced_object][:BBox] }
+  end
+end

--- a/test/fixtures/files/shared_stream_form_xobjects.pdf
+++ b/test/fixtures/files/shared_stream_form_xobjects.pdf
@@ -1,0 +1,42 @@
+%PDF-1.4
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+2 0 obj
+<</Type/Pages/Count 1/Kids[3 0 R]>>
+endobj
+3 0 obj
+<</Type/Page/MediaBox[0 0 200 200]/Parent 2 0 R/Resources<</XObject<</Left 4 0 R/Right 5 0 R>>>>/Contents 6 0 R>>
+endobj
+4 0 obj
+<</Type/XObject/Subtype/Form/BBox[0 0 90 200]/Length 25>>
+stream
+0 0 1 rg 0 0 200 200 re f
+endstream
+endobj
+5 0 obj
+<</Type/XObject/Subtype/Form/BBox[110 0 200 200]/Length 25>>
+stream
+0 0 1 rg 0 0 200 200 re f
+endstream
+endobj
+6 0 obj
+<</Length 17>>
+stream
+/Left Do /Right Do
+endstream
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000009 00000 n 
+0000000054 00000 n 
+0000000105 00000 n 
+0000000234 00000 n 
+0000000350 00000 n 
+0000000469 00000 n 
+trailer
+<</Size 7/Root 1 0 R>>
+startxref
+535
+%%EOF


### PR DESCRIPTION
Fixes #218

**Problem**

Deduplication in `to_pdf` is broken, and elements go missing from the output. Two objects that share stream bytes but differ in an array value, such as a `BBox`, `Matrix` or `ColorSpace`, are merged into one, and whatever the dropped object drew disappears. Genuinely identical objects that contain an array are never merged, so the deduplication rarely helps either.

Both come from one inverted comparison. When writing a PDF, add_referenced treats two objects as candidates for sharing when their stream bytes match, then asks `equal_layers` whether their dictionaries match. The Array branch of `equal_layers` is:

`(obj1-obj2).any? || (obj2-obj1).any?`

The method's contract is "return true when the two things are equal". This expression answers the opposite question, "is there any difference?".

```
[1, 2] - [1, 2]   # => []       .any? => false   reported as different
[1, 2] - [3, 4]   # => [1, 2]   .any? => true    reported as equal
```

**Real PDF's used for testing the fix**:

- #218: a payment slip draws its barcode from two 10×80 one-bit images with identical pixel streams whose ColorSpace arrays reference different palettes (black and white). They merge into one image and the barcode vanishes.
- A personal 12-page PDF assembled as a collage, where each visible region is a small form XObject whose stream is just 
`/fullpage` Do and which differs only in BBox and Matrix. Every region on a page collapses onto one of them, so logos and tables disappear and other regions are drawn twice.

**Note**

PR #219 fixes the same symptom by deleting the `raw_stream_content` lookup, which removes content deduplication entirely. This branch keeps deduplication and repairs the comparison. Measured by combining a 10-page, 2.7 MB document with itself:

| build       | output size |
|-------------|-------------|
| master      | 5.2 MB      |
| #219        | 5.5 MB      |
| this PR | 2.9 MB      |

Master was already barely deduplicating, because the same inverted check refused to merge identical objects that contain an array. With the comparison fixed, dedup works as intended.